### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#videoconverter.js
+# videoconverter.js
 
 videoconverter.js is a library that allows you to convert and manipulate videos inside of your web browser.
 

--- a/build/ffmpeg/INSTALL.md
+++ b/build/ffmpeg/INSTALL.md
@@ -1,4 +1,4 @@
-#Installing FFmpeg:
+# Installing FFmpeg:
 
 1. Type `./configure` to create the configuration. A list of configure
 options is printed by running `configure --help`.

--- a/build/ffmpeg/LICENSE.md
+++ b/build/ffmpeg/LICENSE.md
@@ -1,4 +1,4 @@
-#FFmpeg:
+# FFmpeg:
 
 Most files in FFmpeg are under the GNU Lesser General Public License version 2.1
 or later (LGPL v2.1+). Read the file COPYING.LGPLv2.1 for details. Some other


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
